### PR TITLE
docs: add Vaillant and Migo parameters in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@
 
 ## Configuration is done in the UI
 
+Check out the [community page](https://community.home-assistant.io/t/added-support-for-vaillant-thermostat-how-to-integrate-in-official-release/31858). You can find out how to extract client ID and client secret there.
+
+For Vaillant Vsmart
+- Client ID : na_client_android_vaillant
+- Client secret : 929XXXXXXXXXXXXXXXX45f0 (see above)
+- Username : MY_VAILLANT_APP_USERNAME
+- Password : MY_VAILLANT_APP_PWD
+- User prefix : vaillant
+- App version : 1.0.4.0
+
+For MiGo
+- Client ID : na_client_android_sdbg
+- Client secret : 28d36XXXXXXXXXXXXffeb (see above)
+- Username : MY_MIGO_APP_USERNAME
+- Password : MY_MIGO_APP_PWD
+- User prefix : sdbg
+- App version : 1.3.0.4
+
 <!---->
 
 ## Contributions are welcome!

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Check out the [community page](https://community.home-assistant.io/t/added-suppo
 
 For Vaillant Vsmart
 - Client ID : na_client_android_vaillant
-- Client secret : 929XXXXXXXXXXXXXXXX45f0 (see above)
+- Client secret : XXXXXXXXXXXXXXXXXXXXXXX (see above)
 - Username : MY_VAILLANT_APP_USERNAME
 - Password : MY_VAILLANT_APP_PWD
 - User prefix : vaillant
@@ -55,7 +55,7 @@ For Vaillant Vsmart
 
 For MiGo
 - Client ID : na_client_android_sdbg
-- Client secret : 28d36XXXXXXXXXXXXffeb (see above)
+- Client secret : XXXXXXXXXXXXXXXXXXXXXXX (see above)
 - Username : MY_MIGO_APP_USERNAME
 - Password : MY_MIGO_APP_PWD
 - User prefix : sdbg


### PR DESCRIPTION
Description of basic informations. Method to obtain client credentials is aligned with the integration help text.