### PR TITLE
HVACAction.HEATING is based on boiler_status attribute

### DIFF
--- a/custom_components/vaillant_vsmart/climate.py
+++ b/custom_components/vaillant_vsmart/climate.py
@@ -125,7 +125,7 @@ class VaillantClimate(VaillantEntity, ClimateEntity):
             return HVACAction.OFF
 
         try:
-            if self._module.measured.temperature < self._module.measured.setpoint_temp:
+            if self._module.boiler_status == True:
                 return HVACAction.HEATING
         except TypeError:
             pass

--- a/custom_components/vaillant_vsmart/climate.py
+++ b/custom_components/vaillant_vsmart/climate.py
@@ -124,11 +124,8 @@ class VaillantClimate(VaillantEntity, ClimateEntity):
         if self._device.system_mode == SystemMode.FROSTGUARD:
             return HVACAction.OFF
 
-        try:
-            if self._module.boiler_status == True:
-                return HVACAction.HEATING
-        except TypeError:
-            pass
+        if self._module.boiler_status == True:
+            return HVACAction.HEATING
 
         return HVACAction.IDLE
 


### PR DESCRIPTION
hvac_action is not calculated it is determined by boiler_status -> need to update [vaillant-netatmo-api] accordingly (pull request #100)