### PR TITLE
fix: homeassistant.components deprecations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "mislavmandaric/home-assistant-vaillant-vsmart",
-	"image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/python:3.12-bullseye",
 	"postCreateCommand": "scripts/setup",
 	"forwardPorts": [
 		8123

--- a/custom_components/vaillant_vsmart/manifest.json
+++ b/custom_components/vaillant_vsmart/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/issues",
   "requirements": [
-    "vaillant-netatmo-api==0.10.0"
+    "vaillant-netatmo-api==0.11.0"
   ],
-  "version": "0.8.0"
+  "version": "0.9.0"
 }

--- a/custom_components/vaillant_vsmart/websockets.py
+++ b/custom_components/vaillant_vsmart/websockets.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.components.websocket_api import (
     decorators,
     ActiveConnection,
+    async_register_command,
 )
 
 
@@ -113,9 +114,10 @@ async def websocket_get_tags(
 async def async_register_websockets(hass: HomeAssistant) -> None:
     """TODO."""
 
-    hass.components.websocket_api.async_register_command(websocket_get_schedules)
-    hass.components.websocket_api.async_register_command(websocket_get_schedule_item)
-    hass.components.websocket_api.async_register_command(
+    async_register_command(hass, websocket_get_schedules)
+    async_register_command(hass, websocket_get_schedule_item)
+    async_register_command(
+        hass,
         websocket_schedule_item_updated
     )
-    hass.components.websocket_api.async_register_command(websocket_get_tags)
+    async_register_command(hass, websocket_get_tags)

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
     "name": "Vaillant vSMART",
-    "homeassistant": "2023.11"
+    "homeassistant": "2024.5"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 colorlog==6.7.0
-homeassistant==2023.12.1
+homeassistant==2024.5.1
 pip>=21.0,<23.2
-pytest==7.4.3
-pytest-homeassistant-custom-component==0.13.83
+pytest==8.1.1
+pytest-homeassistant-custom-component==0.13.121
 ruff==0.0.292
+vaillant-netatmo-api==0.11.0


### PR DESCRIPTION
this fixes #335 

To make sure everything works, I had to update the dependencies.
Tested it locally, but I admit I could not run the tests as it seems the tests were not updated during the past refactorings....