### PR TITLE
Updated config to fix warning and updated dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [0.10.0](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/compare/v0.9.0...v0.10.0) (2024-07-02)
+
+
+### Bug Fixes
+
+* homeassistant.components deprecations ([#336](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/issues/336)) ([0baa2a3](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/commit/0baa2a3cda8382092f4cd6e8385ed7a6e48eb8de))
+
+
+### Features
+
+* Add new sensor for outdoor temperature ([#344](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/issues/344)) ([58f51b1](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/commit/58f51b16249f1199554ff921af1a432fb9abfa18))
+* Improve energy consumption implementation with additional sensor for duration of boiler being on ([#343](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/issues/343)) ([a581a77](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/commit/a581a77c824894b8f72f9edff55dcc0e3dfac3cf))
+* Separate hwb switch for boiler device ([#345](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/issues/345)) ([a867e16](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/commit/a867e16fb98149b301d75c13b662839fb0410e60))
+
 # [0.10.0-dev.3](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/compare/v0.10.0-dev.2...v0.10.0-dev.3) (2024-06-30)
 
 

--- a/custom_components/vaillant_vsmart/__init__.py
+++ b/custom_components/vaillant_vsmart/__init__.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_TOKEN
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.core_config import Config
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.httpx_client import get_async_client
 from vaillant_netatmo_api import ThermostatClient, Token, TokenStore

--- a/custom_components/vaillant_vsmart/climate.py
+++ b/custom_components/vaillant_vsmart/climate.py
@@ -53,7 +53,7 @@ class VaillantClimate(VaillantModuleEntity, ClimateEntity):
     """Vaillant vSMART Climate."""
 
     @property
-    def name(self) -> str:
+    def name(self) -> str|None:
         """Return the name of the climate."""
 
         return None

--- a/custom_components/vaillant_vsmart/manifest.json
+++ b/custom_components/vaillant_vsmart/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "vaillant-netatmo-api==0.11.0"
   ],
-  "version": "0.10.0-dev.3"
+  "version": "0.10.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
 colorlog==6.7.0
-homeassistant==2024.6.4
-pip>=21.0,<23.2
-pytest==8.2.0
-pytest-homeassistant-custom-component==0.13.136
+homeassistant==2024.12.0
+pip>=24.3
+pytest==8.3.3
+pytest-homeassistant-custom-component==0.13.190
 ruff==0.5.0
+vaillant-netatmo-api==0.11.0
+aiohttp~=3.11.9
+voluptuous~=0.15.2
+asyncio~=3.4.3


### PR DESCRIPTION
Hi, I have updated dependencies and fixed the following warning at startup :
```2024-12-04 17:32:11.180 WARNING (ImportExecutor_0) [homeassistant.core] Config was used from vaillant_vsmart, this is a deprecated alias which will be removed in HA Core 2025.11. Use homeassistant.core_config.Config instead, please report it to the author of the 'vaillant_vsmart' custom integration```

Tested successfully on my setup