### PR TITLE
fix: update Config import to use ConfigType from helpers.typing

### DIFF
--- a/custom_components/vaillant_vsmart/__init__.py
+++ b/custom_components/vaillant_vsmart/__init__.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_TOKEN
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.helpers.typing import ConfigType
 from vaillant_netatmo_api import ThermostatClient, Token, TokenStore
 
 from .const import (
@@ -24,7 +25,7 @@ from .websockets import async_register_websockets
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
-async def async_setup(hass: HomeAssistant, config: Config) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Vaillant vSMART component."""
 
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/vaillant_vsmart/switch.py
+++ b/custom_components/vaillant_vsmart/switch.py
@@ -2,14 +2,13 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
 
 from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from vaillant_netatmo_api import ApiException, SetpointMode
+from vaillant_netatmo_api import ApiException
 
 from .const import DOMAIN
 from .entity import VaillantCoordinator, VaillantDeviceEntity, VaillantProgramEntity


### PR DESCRIPTION
Following Home Assistant Core changes described in:
https://developers.home-assistant.io/blog/2024/10/31/core-config-moved