### PR TITLE
Improve multi-home reliability by adding explicit home_id targeting (with options dropdown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.11.2-dev.1](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/compare/v0.11.1...v0.11.2-dev.1) (2025-10-25)
+
+
+### Bug Fixes
+
+* update Config import to use ConfigType from helpers.typing ([#424](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/issues/424)) ([95eacd5](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/commit/95eacd532be19b158971db505f70de054e9bfcd6))
+
 ## [0.11.1](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/compare/v0.11.0...v0.11.1) (2025-08-01)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.11.2](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/compare/v0.11.1...v0.11.2) (2025-10-25)
+
+
+### Bug Fixes
+
+* update Config import to use ConfigType from helpers.typing ([#425](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/issues/425)) ([a2df89b](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/commit/a2df89bd5da89abc2bf50d96daa4fcd07c3931c2))
+
 ## [0.11.2-dev.1](https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/compare/v0.11.1...v0.11.2-dev.1) (2025-10-25)
 
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ For MiGo
 - User prefix : sdbg
 - App version : 1.3.0.4
 
+### Optional `home_id` targeting
+
+If your Netatmo account returns multiple homes with the same name, writes to `syncapi/v1/setstate` can fail for one home and succeed for another.
+
+Use integration options to set:
+- `home_id` (recommended when multiple homes exist)
+
+If these values are not set:
+- one home: the integration keeps existing behavior
+- multiple homes: service calls fail with an actionable error listing available IDs
+
+You can discover IDs using the smoke test in the `vaillant-netatmo-api` repo:
+- `uv run python tools/smoke_home_selection.py`
+
 <!---->
 
 ## Contributions are welcome!

--- a/custom_components/vaillant_vsmart/__init__.py
+++ b/custom_components/vaillant_vsmart/__init__.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_TOKEN
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.helpers.typing import ConfigType
 from vaillant_netatmo_api import ThermostatClient, Token, TokenStore
 
 from .const import (
@@ -24,7 +25,7 @@ from .websockets import async_register_websockets
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
-async def async_setup(hass: HomeAssistant, config: Config) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Vaillant vSMART component."""
 
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/vaillant_vsmart/__init__.py
+++ b/custom_components/vaillant_vsmart/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.typing import ConfigType
 from vaillant_netatmo_api import ThermostatClient, Token, TokenStore
 
 from .const import (
+    CONF_HOME_ID,
     DOMAIN,
     PLATFORMS,
 )
@@ -53,7 +54,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         TokenStore(client_id, client_secret, token, handle_token_update),
     )
 
-    coordinator = VaillantCoordinator(hass, client)
+    selected_home_id = entry.options.get(CONF_HOME_ID, entry.data.get(CONF_HOME_ID))
+
+    coordinator = VaillantCoordinator(
+        hass,
+        client,
+        selected_home_id=selected_home_id,
+    )
     await coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = coordinator

--- a/custom_components/vaillant_vsmart/config_flow.py
+++ b/custom_components/vaillant_vsmart/config_flow.py
@@ -18,6 +18,8 @@ from vaillant_netatmo_api import (
     ApiException,
     AuthClient,
     RequestClientException,
+    ThermostatClient,
+    Token,
     TokenStore,
 )
 import voluptuous as vol
@@ -193,14 +195,47 @@ class VaillantOptionsFlowHandler(config_entries.OptionsFlow):
             CONF_HOME_ID, self._config_entry.data.get(CONF_HOME_ID, "")
         )
 
+        home_options = await self._async_home_options(current_home_id)
+        if home_options:
+            selector: Any = vol.In(home_options)
+        else:
+            selector = str
+
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Optional(CONF_HOME_ID, default=current_home_id): str,
+                    vol.Optional(CONF_HOME_ID, default=current_home_id): selector,
                 }
             ),
         )
+
+    async def _async_home_options(self, current_home_id: str) -> dict[str, str]:
+        try:
+            client_id = self._config_entry.data.get(CONF_CLIENT_ID)
+            client_secret = self._config_entry.data.get(CONF_CLIENT_SECRET)
+            token = Token.deserialize(self._config_entry.data.get(CONF_TOKEN))
+            thermostat_client = ThermostatClient(
+                get_async_client(self.hass),
+                TokenStore(client_id, client_secret, token, None),
+            )
+            homes = await thermostat_client.async_get_homes_data()
+        except Exception as ex:  # pylint: disable=broad-except
+            _LOGGER.warning("Failed to load homes for home_id dropdown, using text input: %s", ex)
+            return {}
+
+        options = {"": "Auto (single-home fallback)"}
+        for home in homes:
+            if home.id is None:
+                continue
+            home_id = str(home.id)
+            home_name = (home.name or "").strip()
+            options[home_id] = f"{home_name} ({home_id})" if home_name else home_id
+
+        if current_home_id and current_home_id not in options:
+            options[current_home_id] = f"{current_home_id} (configured)"
+
+        return options
 
 
 def _extract_target_ids(user_input: dict[str, Any]) -> dict[str, str]:

--- a/custom_components/vaillant_vsmart/config_flow.py
+++ b/custom_components/vaillant_vsmart/config_flow.py
@@ -24,6 +24,7 @@ import voluptuous as vol
 
 from .const import (
     CONF_APP_VERSION,
+    CONF_HOME_ID,
     CONF_USER_PREFIX,
     DOMAIN,
 )
@@ -35,6 +36,10 @@ class VaillantFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for vaillant_vsmart."""
 
     VERSION = 1
+
+    @staticmethod
+    def async_get_options_flow(config_entry):
+        return VaillantOptionsFlowHandler(config_entry)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -115,6 +120,9 @@ class VaillantFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(
                         CONF_APP_VERSION, default=user_input.get(CONF_APP_VERSION)
                     ): str,
+                    vol.Optional(
+                        CONF_HOME_ID, default=user_input.get(CONF_HOME_ID, "")
+                    ): str,
                 }
             ),
             errors=errors,
@@ -133,6 +141,7 @@ class VaillantFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_CLIENT_SECRET: data.get(CONF_CLIENT_SECRET),
             CONF_USER_PREFIX: data.get(CONF_USER_PREFIX),
             CONF_APP_VERSION: data.get(CONF_APP_VERSION),
+            CONF_HOME_ID: data.get(CONF_HOME_ID, ""),
         }
 
     async def _get_config_storage_data(
@@ -159,10 +168,44 @@ class VaillantFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             user_input.get(CONF_APP_VERSION),
         )
 
-        return {
+        data = {
             CONF_CLIENT_ID: user_input.get(CONF_CLIENT_ID),
             CONF_CLIENT_SECRET: user_input.get(CONF_CLIENT_SECRET),
             CONF_USER_PREFIX: user_input.get(CONF_USER_PREFIX),
             CONF_APP_VERSION: user_input.get(CONF_APP_VERSION),
             CONF_TOKEN: token_store.token.serialize(),
         }
+        data.update(_extract_target_ids(user_input))
+        return data
+
+
+class VaillantOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Vaillant vSMART options."""
+
+    def __init__(self, config_entry):
+        self._config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        if user_input is not None:
+            return self.async_create_entry(title="", data=_extract_target_ids(user_input))
+
+        current_home_id = self._config_entry.options.get(
+            CONF_HOME_ID, self._config_entry.data.get(CONF_HOME_ID, "")
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(CONF_HOME_ID, default=current_home_id): str,
+                }
+            ),
+        )
+
+
+def _extract_target_ids(user_input: dict[str, Any]) -> dict[str, str]:
+    data: dict[str, str] = {}
+    home_id = (user_input.get(CONF_HOME_ID) or "").strip()
+    if home_id:
+        data[CONF_HOME_ID] = home_id
+    return data

--- a/custom_components/vaillant_vsmart/const.py
+++ b/custom_components/vaillant_vsmart/const.py
@@ -17,6 +17,7 @@ PLATFORMS = [CLIMATE, NUMBER, SELECT, SENSOR, SWITCH, WATER_HEATER]
 # Configuration and options
 CONF_APP_VERSION = "app_version"
 CONF_USER_PREFIX = "user_prefix"
+CONF_HOME_ID = "home_id"
 
 SUPPORTED_ENERGY_MEASUREMENT_TYPES = [MeasurementType.SUM_ENERGY_GAS_HEATING, MeasurementType.SUM_ENERGY_GAS_WATER,
                                       MeasurementType.SUM_ENERGY_ELEC_HEATING, MeasurementType.SUM_ENERGY_ELEC_WATER]

--- a/custom_components/vaillant_vsmart/entity.py
+++ b/custom_components/vaillant_vsmart/entity.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -29,6 +29,40 @@ from .const import DOMAIN, SUPPORTED_ENERGY_MEASUREMENT_TYPES, SUPPORTED_DURATIO
 UPDATE_INTERVAL = timedelta(minutes=5)
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
+
+
+def _format_homes(homes: dict[str, Home]) -> str:
+    return ", ".join(f"{home.id} ({home.name})" for home in homes.values())
+
+
+def _select_home(data: "VaillantData", selected_home_id: str | None) -> Home:
+    if selected_home_id:
+        configured = data.homes.get(selected_home_id)
+        if configured is not None:
+            return configured
+
+        raise HomeAssistantError(
+            f"Configured home_id '{selected_home_id}' was not found. "
+            f"Available homes: {_format_homes(data.homes)}"
+        )
+
+    if len(data.homes) == 1:
+        return next(iter(data.homes.values()))
+
+    if len(data.homes) == 0:
+        raise HomeAssistantError("No homes returned by the Vaillant API.")
+
+    raise HomeAssistantError(
+        "Multiple homes detected. Configure home_id in Vaillant vSMART options. "
+        f"Available homes: {_format_homes(data.homes)}"
+    )
+
+
+def _select_room(home: Home) -> Room:
+    rooms = home.rooms
+    if len(rooms) == 0:
+        raise HomeAssistantError(f"No rooms returned for home_id '{home.id}'.")
+    return rooms[0]
 
 
 class VaillantData:
@@ -59,7 +93,12 @@ class VaillantData:
 class VaillantCoordinator(DataUpdateCoordinator[VaillantData]):
     """Class to manage fetching data from the API."""
 
-    def __init__(self, hass: HomeAssistant, client: ThermostatClient) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: ThermostatClient,
+        selected_home_id: str | None = None,
+    ) -> None:
         """Initialize."""
 
         super().__init__(
@@ -71,6 +110,7 @@ class VaillantCoordinator(DataUpdateCoordinator[VaillantData]):
         )
 
         self._client = client
+        self.selected_home_id = selected_home_id
 
     async def _update_method(self):
         """Fetch data from API endpoint.
@@ -122,22 +162,17 @@ class VaillantDeviceEntity(CoordinatorEntity[VaillantData]):
     @property
     def _home(self) -> Home:
         """Return the device which this entity represents."""
-
-        # TODO: Remove this hack
-        # We assume there is only one home and one room
-        # This assumption will be removed when we switch entirely to using new APIs
-        for id in self.coordinator.data.homes:
-            return self.coordinator.data.homes[id]
+        home = _select_home(self.coordinator.data, self.coordinator.selected_home_id)
+        _LOGGER.debug("Selected home_id=%s (configured_home_id=%s)", home.id, self.coordinator.selected_home_id)
+        return home
 
     @property
     def _room(self) -> Room:
         """Return the device which this entity represents."""
-
-        # TODO: Remove this hack
-        # We assume there is only one home and one room
-        # This assumption will be removed when we switch entirely to using new APIs
-        for id in self.coordinator.data.rooms:
-            return self.coordinator.data.rooms[id]
+        home = self._home
+        room = _select_room(home)
+        _LOGGER.debug("Selected room_id=%s for home_id=%s", room.id, home.id)
+        return room
 
     @property
     def _device(self) -> Device:
@@ -194,22 +229,17 @@ class VaillantModuleEntity(CoordinatorEntity[VaillantData]):
     @property
     def _home(self) -> Home:
         """Return the device which this entity represents."""
-
-        # TODO: Remove this hack
-        # We assume there is only one home and one room
-        # This assumption will be removed when we switch entirely to using new APIs
-        for id in self.coordinator.data.homes:
-            return self.coordinator.data.homes[id]
+        home = _select_home(self.coordinator.data, self.coordinator.selected_home_id)
+        _LOGGER.debug("Selected home_id=%s (configured_home_id=%s)", home.id, self.coordinator.selected_home_id)
+        return home
 
     @property
     def _room(self) -> Room:
         """Return the device which this entity represents."""
-
-        # TODO: Remove this hack
-        # We assume there is only one home and one room
-        # This assumption will be removed when we switch entirely to using new APIs
-        for id in self.coordinator.data.rooms:
-            return self.coordinator.data.rooms[id]
+        home = self._home
+        room = _select_room(home)
+        _LOGGER.debug("Selected room_id=%s for home_id=%s", room.id, home.id)
+        return room
 
     @property
     def _device(self) -> Device:

--- a/custom_components/vaillant_vsmart/manifest.json
+++ b/custom_components/vaillant_vsmart/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "vaillant-netatmo-api==0.13.1"
   ],
-  "version": "0.11.2-dev.1"
+  "version": "0.11.2"
 }

--- a/custom_components/vaillant_vsmart/manifest.json
+++ b/custom_components/vaillant_vsmart/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "vaillant-netatmo-api==0.13.1"
   ],
-  "version": "0.11.1"
+  "version": "0.11.2-dev.1"
 }

--- a/custom_components/vaillant_vsmart/switch.py
+++ b/custom_components/vaillant_vsmart/switch.py
@@ -2,14 +2,13 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
 
 from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from vaillant_netatmo_api import ApiException, SetpointMode
+from vaillant_netatmo_api import ApiException
 
 from .const import DOMAIN
 from .entity import VaillantCoordinator, VaillantDeviceEntity, VaillantProgramEntity

--- a/custom_components/vaillant_vsmart/translations/en.json
+++ b/custom_components/vaillant_vsmart/translations/en.json
@@ -9,7 +9,8 @@
                     "username": "Username",
                     "password": "Password",
                     "user_prefix": "User prefix",
-                    "app_version": "App version"
+                    "app_version": "App version",
+                    "home_id": "Home ID (optional)"
                 }
             },
             "reauth": {
@@ -20,7 +21,18 @@
                     "username": "Username",
                     "password": "Password",
                     "user_prefix": "User prefix",
-                    "app_version": "App version"
+                    "app_version": "App version",
+                    "home_id": "Home ID (optional)"
+                }
+            }
+        },
+        "options": {
+            "step": {
+                "init": {
+                    "description": "Set optional target home ID when your account has multiple homes.",
+                    "data": {
+                        "home_id": "Home ID (optional)"
+                    }
                 }
             }
         },

--- a/tests/test_home_selection.py
+++ b/tests/test_home_selection.py
@@ -1,0 +1,45 @@
+"""Tests for home selection."""
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+from vaillant_netatmo_api import Home
+
+from custom_components.vaillant_vsmart.entity import VaillantData, _select_home, _select_room
+
+
+def _make_data(homes: list[Home]) -> VaillantData:
+    return VaillantData(client=None, homes=homes, devices=[], measurements={})
+
+
+def test_select_home_uses_configured_home_id() -> None:
+    homes = [
+        Home(id="home_a", name="Wildenborch", rooms=[{"id": "room_a"}]),
+        Home(id="home_b", name="Wildenborch", rooms=[{"id": "room_b"}]),
+    ]
+    data = _make_data(homes)
+
+    selected = _select_home(data, "home_b")
+
+    assert selected.id == "home_b"
+
+
+def test_select_home_raises_when_multiple_homes_without_configuration() -> None:
+    homes = [
+        Home(id="home_a", name="Wildenborch", rooms=[{"id": "room_a"}]),
+        Home(id="home_b", name="Wildenborch", rooms=[{"id": "room_b"}]),
+    ]
+    data = _make_data(homes)
+
+    with pytest.raises(HomeAssistantError, match="Multiple homes detected"):
+        _select_home(data, None)
+
+
+def test_select_room_uses_first_room() -> None:
+    home = Home(
+        id="home_a",
+        name="Wildenborch",
+        rooms=[{"id": "room_a"}, {"id": "room_b"}],
+    )
+
+    selected = _select_room(home)
+    assert selected.id == "room_a"


### PR DESCRIPTION
## Summary
This PR improves thermostat write reliability for Netatmo accounts with multiple homes by adding explicit `home_id` targeting in the integration.

It addresses cases where `homesdata` returns multiple homes (sometimes with identical names), but only one home accepts `syncapi/v1/setstate` writes.

## Problem
The integration previously used a first-item home selection assumption in entity helpers.  
In multi-home accounts, this could target the wrong home and cause failed writes (for example HTTP `406` / `"Nothing to update"`).

## Changes
- Added `home_id` support in config/constants and runtime wiring.
- Replaced implicit first-home selection with deterministic logic:
  - Use configured `home_id` when provided and valid.
  - Auto-select only when exactly one home exists (backward-compatible behavior).
  - If multiple homes and no `home_id`, raise actionable `HomeAssistantError` listing available home IDs.
- Kept room selection simple (first room in selected home); no `room_id` config.
- Added DEBUG logging for selected home/room IDs.
- Added/updated options flow UX:
  - `home_id` is shown as a dropdown when homes can be loaded (`<home_name> (<home_id>)`).
  - Includes `Auto (single-home fallback)`.
  - Falls back to text input if loading homes fails.
- Updated docs and translations for `home_id` setup.

## Why this approach
- Minimal, low-risk, local integration change.
- No upstream `vaillant-netatmo-api` changes.
- Preserves behavior for single-home users.
- Makes multi-home behavior explicit and predictable.

## User impact
- **Single-home users:** no expected behavior change.
- **Multi-home users:** can explicitly select the controlling home via integration options, avoiding write failures to non-controlling homes.

## Validation
- Manual validation against a multi-home account (one writable home, one non-writable home).
- Local syntax checks passed.
- Existing behavior for non-ambiguous setups preserved by fallback logic.

## Follow-ups (optional)
- Add tests for options-flow dropdown success/fallback paths.
- Explore automatic per-device home mapping from richer raw payloads, keeping `home_id` as override.
