### PR TITLE
Fix non-string firmware versions

### DIFF
--- a/custom_components/vaillant_vsmart/entity.py
+++ b/custom_components/vaillant_vsmart/entity.py
@@ -31,6 +31,12 @@ UPDATE_INTERVAL = timedelta(minutes=5)
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
+def _format_firmware_version(firmware: object) -> str | None:
+    """Return a firmware version compatible with the device registry."""
+
+    return None if firmware is None else str(firmware)
+
+
 class VaillantData:
     """Class holding data which coordinator provides to the entity."""
 
@@ -164,7 +170,7 @@ class VaillantDeviceEntity(CoordinatorEntity[VaillantData]):
         return {
             "identifiers": {(DOMAIN, self._device.id)},
             "name": self._device.station_name,
-            "sw_version": self._device.firmware,
+            "sw_version": _format_firmware_version(self._device.firmware),
             "manufacturer": self._device.type,
         }
 
@@ -242,7 +248,7 @@ class VaillantModuleEntity(CoordinatorEntity[VaillantData]):
         return {
             "identifiers": {(DOMAIN, self._module.id)},
             "name": self._module.module_name,
-            "sw_version": self._module.firmware,
+            "sw_version": _format_firmware_version(self._module.firmware),
             "manufacturer": self._device.type,
             "via_device": (DOMAIN, self._device.id),
         }
@@ -309,7 +315,7 @@ class VaillantProgramEntity(CoordinatorEntity[VaillantData]):
         return {
             "identifiers": {(DOMAIN, self._module.id)},
             "name": self._module.module_name,
-            "sw_version": self._module.firmware,
+            "sw_version": _format_firmware_version(self._module.firmware),
             "manufacturer": self._device.type,
             "via_device": (DOMAIN, self._device.id),
         }
@@ -381,7 +387,7 @@ class VaillantMeasurementEntity(CoordinatorEntity[VaillantData]):
         return {
             "identifiers": {(DOMAIN, self._module.id)},
             "name": self._module.module_name,
-            "sw_version": self._module.firmware,
+            "sw_version": _format_firmware_version(self._module.firmware),
             "manufacturer": self._device.type,
             "via_device": (DOMAIN, self._device.id),
         }

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,11 @@
+"""Test Vaillant vSMART entities."""
+
+from custom_components.vaillant_vsmart.entity import _format_firmware_version
+
+
+def test_format_firmware_version() -> None:
+    """Test firmware versions are compatible with the device registry."""
+
+    assert _format_firmware_version(42) == "42"
+    assert _format_firmware_version("3.2.1") == "3.2.1"
+    assert _format_firmware_version(None) is None


### PR DESCRIPTION
## Summary

- normalize device and module firmware versions before passing them to Home Assistant device info
- preserve missing firmware values as `None`
- add unit coverage for integer, string, and missing firmware versions

This prevents the device registry warning that will become an error in Home Assistant 2026.12.

Fixes #431

## Validation

- `ruff check custom_components/vaillant_vsmart/entity.py tests/test_entity.py`
- `python3 -m compileall -q custom_components/vaillant_vsmart tests/test_entity.py`
- `git diff --check`